### PR TITLE
Client list images

### DIFF
--- a/src/thumbtack_client/__init__.py
+++ b/src/thumbtack_client/__init__.py
@@ -57,7 +57,7 @@ class ThumbtackClient(object):
         Returns
         -------
         dict
-            A JSON serialized dictionary of all images in: 'http://127.0.0.1:8208/images/'
+            A JSON serialized dictionary of all images in: 'http://127.0.0.1:8208/images'
         """
         url = f"{self._url}/images"
         response = self._get(url, expected_status=200)

--- a/src/thumbtack_client/__init__.py
+++ b/src/thumbtack_client/__init__.py
@@ -45,8 +45,8 @@ class ThumbtackClient(object):
         """
         Returns
         -------
-        dict
-            A JSON serialized dictionary of all mounted images in: 'http://127.0.0.1:8208/mounts/'
+        list
+            A list of JSON serialized dictionaries of all mounted images in: 'http://127.0.0.1:8208/mounts/'
         """
         url = f"{self._url}/mounts/"
         response = self._get(url, expected_status=200)
@@ -56,8 +56,8 @@ class ThumbtackClient(object):
         """
         Returns
         -------
-        dict
-            A JSON serialized dictionary of all images in: 'http://127.0.0.1:8208/images'
+        list
+            A list of JSON serialized dictionaries of all images in: 'http://127.0.0.1:8208/images'
         """
         url = f"{self._url}/images"
         response = self._get(url, expected_status=200)

--- a/src/thumbtack_client/__init__.py
+++ b/src/thumbtack_client/__init__.py
@@ -52,6 +52,17 @@ class ThumbtackClient(object):
         response = self._get(url, expected_status=200)
         return response.json()
 
+    def list_images(self):
+        """
+        Returns
+        -------
+        dict
+            A JSON serialized dictionary of all images in: 'http://127.0.0.1:8208/images/'
+        """
+        url = f"{self._url}/images"
+        response = self._get(url, expected_status=200)
+        return response.json()
+
     def mount_image(self, image_path):
         """
         Parameters

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -17,14 +17,14 @@ def test_smoke():
 def test_list_images_empty(client):
     responses.add(responses.GET, 'http://127.0.0.1:8208/images', '[]')
 
-    response = client.list_mounted_images()
+    response = client.list_images()
     assert response == []
 
 @responses.activate
 def test_list_images_populated(client):
     responses.add(responses.GET, 'http://127.0.0.1:8208/images', '[1, 2, 3]')
 
-    response = client.list_mounted_images()
+    response = client.list_images()
     assert len(response) > 0
 
 @responses.activate

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -13,6 +13,19 @@ def client():
 def test_smoke():
     assert thumbtack_client.MountedDiskImage.MountedDiskImage is not None
 
+@responses.activate
+def test_list_images_empty(client):
+    responses.add(responses.GET, 'http://127.0.0.1:8208/images', '[]')
+
+    response = client.list_mounted_images()
+    assert response == []
+
+@responses.activate
+def test_list_images_populated(client):
+    responses.add(responses.GET, 'http://127.0.0.1:8208/images', '[1, 2, 3]')
+
+    response = client.list_mounted_images()
+    assert len(response) > 0
 
 @responses.activate
 def test_list_mounts_empty(client):


### PR DESCRIPTION
Allow client to contact /images api endpoint on thumbtack. Related to [thumbtack pull request 115](https://github.com/mitre/thumbtack/pull/115)